### PR TITLE
Downgrade Vue from 3 to 2.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,18 +15,18 @@
         "lodash": "^4.17.21",
         "moment": "^2.29.4",
         "tippy.js": "^6.3.7",
-        "vue": "^3.2.37"
+        "vue": "^2.7.12"
       },
       "devDependencies": {
-        "@vitejs/plugin-vue": "^3.0.1",
+        "@vitejs/plugin-vue2": "^2.0.0",
         "sass": "^1.53.0",
         "vite": "^3.0.4"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.10.tgz",
-      "integrity": "sha512-TYk3OA0HKL6qNryUayb5UUEhM/rkOQozIBEA5ITXh5DWrSp0TlUQXMyZmnWxG/DizSWBeeQ0Zbc5z8UGaaqoeg==",
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.4.tgz",
+      "integrity": "sha512-qpVT7gtuOLjWeDTKLkJ6sryqLliBaFpAtGeqw5cs5giLldvh+Ch0plqnUMKoVAUS6ZEueQQiZV+p5pxtPitEsA==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -43,120 +43,28 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
-    "node_modules/@vitejs/plugin-vue": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-3.0.1.tgz",
-      "integrity": "sha512-Ll9JgxG7ONIz/XZv3dssfoMUDu9qAnlJ+km+pBA0teYSXzwPCIzS/e1bmwNYl5dcQGs677D21amgfYAnzMl17A==",
+    "node_modules/@vitejs/plugin-vue2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue2/-/plugin-vue2-2.0.0.tgz",
+      "integrity": "sha512-VJOCDtBNcRv7kYLQRbbERDP0OqW0EKgMQp6wwbqZRpU3kg38OP891avx6Xl3szntGkf9mK4i8k3TjsAlmkzWFg==",
       "dev": true,
       "engines": {
-        "node": "^14.18.0 || >=16.0.0"
+        "node": "^14.18.0 || >= 16.0.0"
       },
       "peerDependencies": {
         "vite": "^3.0.0",
-        "vue": "^3.2.25"
-      }
-    },
-    "node_modules/@vue/compiler-core": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.37.tgz",
-      "integrity": "sha512-81KhEjo7YAOh0vQJoSmAD68wLfYqJvoiD4ulyedzF+OEk/bk6/hx3fTNVfuzugIIaTrOx4PGx6pAiBRe5e9Zmg==",
-      "dependencies": {
-        "@babel/parser": "^7.16.4",
-        "@vue/shared": "3.2.37",
-        "estree-walker": "^2.0.2",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@vue/compiler-dom": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.37.tgz",
-      "integrity": "sha512-yxJLH167fucHKxaqXpYk7x8z7mMEnXOw3G2q62FTkmsvNxu4FQSu5+3UMb+L7fjKa26DEzhrmCxAgFLLIzVfqQ==",
-      "dependencies": {
-        "@vue/compiler-core": "3.2.37",
-        "@vue/shared": "3.2.37"
+        "vue": "^2.7.0-0"
       }
     },
     "node_modules/@vue/compiler-sfc": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.37.tgz",
-      "integrity": "sha512-+7i/2+9LYlpqDv+KTtWhOZH+pa8/HnX/905MdVmAcI/mPQOBwkHHIzrsEsucyOIZQYMkXUiTkmZq5am/NyXKkg==",
+      "version": "2.7.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.12.tgz",
+      "integrity": "sha512-7FOITA2+4ND7lMAfegljHBpNSG3X9mVzgQwcS3g928QZM1EADedUw2JLKcgOm1ZEJEkvyDHh6lwa08vrLmoCOA==",
       "dependencies": {
-        "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.37",
-        "@vue/compiler-dom": "3.2.37",
-        "@vue/compiler-ssr": "3.2.37",
-        "@vue/reactivity-transform": "3.2.37",
-        "@vue/shared": "3.2.37",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7",
-        "postcss": "^8.1.10",
+        "@babel/parser": "^7.18.4",
+        "postcss": "^8.4.14",
         "source-map": "^0.6.1"
       }
-    },
-    "node_modules/@vue/compiler-ssr": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.37.tgz",
-      "integrity": "sha512-7mQJD7HdXxQjktmsWp/J67lThEIcxLemz1Vb5I6rYJHR5vI+lON3nPGOH3ubmbvYGt8xEUaAr1j7/tIFWiEOqw==",
-      "dependencies": {
-        "@vue/compiler-dom": "3.2.37",
-        "@vue/shared": "3.2.37"
-      }
-    },
-    "node_modules/@vue/reactivity": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.37.tgz",
-      "integrity": "sha512-/7WRafBOshOc6m3F7plwzPeCu/RCVv9uMpOwa/5PiY1Zz+WLVRWiy0MYKwmg19KBdGtFWsmZ4cD+LOdVPcs52A==",
-      "dependencies": {
-        "@vue/shared": "3.2.37"
-      }
-    },
-    "node_modules/@vue/reactivity-transform": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.37.tgz",
-      "integrity": "sha512-IWopkKEb+8qpu/1eMKVeXrK0NLw9HicGviJzhJDEyfxTR9e1WtpnnbYkJWurX6WwoFP0sz10xQg8yL8lgskAZg==",
-      "dependencies": {
-        "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.37",
-        "@vue/shared": "3.2.37",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7"
-      }
-    },
-    "node_modules/@vue/runtime-core": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.37.tgz",
-      "integrity": "sha512-JPcd9kFyEdXLl/i0ClS7lwgcs0QpUAWj+SKX2ZC3ANKi1U4DOtiEr6cRqFXsPwY5u1L9fAjkinIdB8Rz3FoYNQ==",
-      "dependencies": {
-        "@vue/reactivity": "3.2.37",
-        "@vue/shared": "3.2.37"
-      }
-    },
-    "node_modules/@vue/runtime-dom": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.37.tgz",
-      "integrity": "sha512-HimKdh9BepShW6YozwRKAYjYQWg9mQn63RGEiSswMbW+ssIht1MILYlVGkAGGQbkhSh31PCdoUcfiu4apXJoPw==",
-      "dependencies": {
-        "@vue/runtime-core": "3.2.37",
-        "@vue/shared": "3.2.37",
-        "csstype": "^2.6.8"
-      }
-    },
-    "node_modules/@vue/server-renderer": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.37.tgz",
-      "integrity": "sha512-kLITEJvaYgZQ2h47hIzPh2K3jG8c1zCVbp/o/bzQOyvzaKiCquKS7AaioPI28GNxIsE/zSx+EwWYsNxDCX95MA==",
-      "dependencies": {
-        "@vue/compiler-ssr": "3.2.37",
-        "@vue/shared": "3.2.37"
-      },
-      "peerDependencies": {
-        "vue": "3.2.37"
-      }
-    },
-    "node_modules/@vue/shared": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.37.tgz",
-      "integrity": "sha512-4rSJemR2NQIo9Klm1vabqWjD8rs/ZaJSzMxkMNeJS6lHiUjjUeYFbooN19NgFjztubEKh3WlZUeOLVdbbUWHsw=="
     },
     "node_modules/anymatch": {
       "version": "3.1.2",
@@ -239,9 +147,9 @@
       }
     },
     "node_modules/csstype": {
-      "version": "2.6.20",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
-      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "node_modules/echarts": {
       "version": "5.3.3",
@@ -607,11 +515,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
-    },
     "node_modules/fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -745,14 +648,6 @@
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
-    },
-    "node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      }
     },
     "node_modules/moment": {
       "version": "2.29.4",
@@ -916,11 +811,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
-    },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -1000,15 +890,12 @@
       }
     },
     "node_modules/vue": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.37.tgz",
-      "integrity": "sha512-bOKEZxrm8Eh+fveCqS1/NkG/n6aMidsI6hahas7pa0w/l7jkbssJVsRhVDs07IdDq7h9KHswZOgItnwJAgtVtQ==",
+      "version": "2.7.12",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.12.tgz",
+      "integrity": "sha512-yRS44vPsCj6b5IZQHdEYqIwnay8stCnL8RsaVsm5aGtOhka00aoG+3ybaBAELDsXtNlzECe8myb2ukdzn19IOg==",
       "dependencies": {
-        "@vue/compiler-dom": "3.2.37",
-        "@vue/compiler-sfc": "3.2.37",
-        "@vue/runtime-dom": "3.2.37",
-        "@vue/server-renderer": "3.2.37",
-        "@vue/shared": "3.2.37"
+        "@vue/compiler-sfc": "2.7.12",
+        "csstype": "^3.1.0"
       }
     },
     "node_modules/zrender": {
@@ -1022,120 +909,31 @@
   },
   "dependencies": {
     "@babel/parser": {
-      "version": "7.18.10",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.10.tgz",
-      "integrity": "sha512-TYk3OA0HKL6qNryUayb5UUEhM/rkOQozIBEA5ITXh5DWrSp0TlUQXMyZmnWxG/DizSWBeeQ0Zbc5z8UGaaqoeg=="
+      "version": "7.19.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.19.4.tgz",
+      "integrity": "sha512-qpVT7gtuOLjWeDTKLkJ6sryqLliBaFpAtGeqw5cs5giLldvh+Ch0plqnUMKoVAUS6ZEueQQiZV+p5pxtPitEsA=="
     },
     "@popperjs/core": {
       "version": "2.11.5",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.5.tgz",
       "integrity": "sha512-9X2obfABZuDVLCgPK9aX0a/x4jaOEweTTWE2+9sr0Qqqevj2Uv5XorvusThmc9XGYpS9yI+fhh8RTafBtGposw=="
     },
-    "@vitejs/plugin-vue": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-3.0.1.tgz",
-      "integrity": "sha512-Ll9JgxG7ONIz/XZv3dssfoMUDu9qAnlJ+km+pBA0teYSXzwPCIzS/e1bmwNYl5dcQGs677D21amgfYAnzMl17A==",
+    "@vitejs/plugin-vue2": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue2/-/plugin-vue2-2.0.0.tgz",
+      "integrity": "sha512-VJOCDtBNcRv7kYLQRbbERDP0OqW0EKgMQp6wwbqZRpU3kg38OP891avx6Xl3szntGkf9mK4i8k3TjsAlmkzWFg==",
       "dev": true,
       "requires": {}
     },
-    "@vue/compiler-core": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.37.tgz",
-      "integrity": "sha512-81KhEjo7YAOh0vQJoSmAD68wLfYqJvoiD4ulyedzF+OEk/bk6/hx3fTNVfuzugIIaTrOx4PGx6pAiBRe5e9Zmg==",
-      "requires": {
-        "@babel/parser": "^7.16.4",
-        "@vue/shared": "3.2.37",
-        "estree-walker": "^2.0.2",
-        "source-map": "^0.6.1"
-      }
-    },
-    "@vue/compiler-dom": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.37.tgz",
-      "integrity": "sha512-yxJLH167fucHKxaqXpYk7x8z7mMEnXOw3G2q62FTkmsvNxu4FQSu5+3UMb+L7fjKa26DEzhrmCxAgFLLIzVfqQ==",
-      "requires": {
-        "@vue/compiler-core": "3.2.37",
-        "@vue/shared": "3.2.37"
-      }
-    },
     "@vue/compiler-sfc": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.37.tgz",
-      "integrity": "sha512-+7i/2+9LYlpqDv+KTtWhOZH+pa8/HnX/905MdVmAcI/mPQOBwkHHIzrsEsucyOIZQYMkXUiTkmZq5am/NyXKkg==",
+      "version": "2.7.12",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-2.7.12.tgz",
+      "integrity": "sha512-7FOITA2+4ND7lMAfegljHBpNSG3X9mVzgQwcS3g928QZM1EADedUw2JLKcgOm1ZEJEkvyDHh6lwa08vrLmoCOA==",
       "requires": {
-        "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.37",
-        "@vue/compiler-dom": "3.2.37",
-        "@vue/compiler-ssr": "3.2.37",
-        "@vue/reactivity-transform": "3.2.37",
-        "@vue/shared": "3.2.37",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7",
-        "postcss": "^8.1.10",
+        "@babel/parser": "^7.18.4",
+        "postcss": "^8.4.14",
         "source-map": "^0.6.1"
       }
-    },
-    "@vue/compiler-ssr": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.37.tgz",
-      "integrity": "sha512-7mQJD7HdXxQjktmsWp/J67lThEIcxLemz1Vb5I6rYJHR5vI+lON3nPGOH3ubmbvYGt8xEUaAr1j7/tIFWiEOqw==",
-      "requires": {
-        "@vue/compiler-dom": "3.2.37",
-        "@vue/shared": "3.2.37"
-      }
-    },
-    "@vue/reactivity": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.37.tgz",
-      "integrity": "sha512-/7WRafBOshOc6m3F7plwzPeCu/RCVv9uMpOwa/5PiY1Zz+WLVRWiy0MYKwmg19KBdGtFWsmZ4cD+LOdVPcs52A==",
-      "requires": {
-        "@vue/shared": "3.2.37"
-      }
-    },
-    "@vue/reactivity-transform": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity-transform/-/reactivity-transform-3.2.37.tgz",
-      "integrity": "sha512-IWopkKEb+8qpu/1eMKVeXrK0NLw9HicGviJzhJDEyfxTR9e1WtpnnbYkJWurX6WwoFP0sz10xQg8yL8lgskAZg==",
-      "requires": {
-        "@babel/parser": "^7.16.4",
-        "@vue/compiler-core": "3.2.37",
-        "@vue/shared": "3.2.37",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7"
-      }
-    },
-    "@vue/runtime-core": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.37.tgz",
-      "integrity": "sha512-JPcd9kFyEdXLl/i0ClS7lwgcs0QpUAWj+SKX2ZC3ANKi1U4DOtiEr6cRqFXsPwY5u1L9fAjkinIdB8Rz3FoYNQ==",
-      "requires": {
-        "@vue/reactivity": "3.2.37",
-        "@vue/shared": "3.2.37"
-      }
-    },
-    "@vue/runtime-dom": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.37.tgz",
-      "integrity": "sha512-HimKdh9BepShW6YozwRKAYjYQWg9mQn63RGEiSswMbW+ssIht1MILYlVGkAGGQbkhSh31PCdoUcfiu4apXJoPw==",
-      "requires": {
-        "@vue/runtime-core": "3.2.37",
-        "@vue/shared": "3.2.37",
-        "csstype": "^2.6.8"
-      }
-    },
-    "@vue/server-renderer": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.37.tgz",
-      "integrity": "sha512-kLITEJvaYgZQ2h47hIzPh2K3jG8c1zCVbp/o/bzQOyvzaKiCquKS7AaioPI28GNxIsE/zSx+EwWYsNxDCX95MA==",
-      "requires": {
-        "@vue/compiler-ssr": "3.2.37",
-        "@vue/shared": "3.2.37"
-      }
-    },
-    "@vue/shared": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.37.tgz",
-      "integrity": "sha512-4rSJemR2NQIo9Klm1vabqWjD8rs/ZaJSzMxkMNeJS6lHiUjjUeYFbooN19NgFjztubEKh3WlZUeOLVdbbUWHsw=="
     },
     "anymatch": {
       "version": "3.1.2",
@@ -1185,9 +983,9 @@
       }
     },
     "csstype": {
-      "version": "2.6.20",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.20.tgz",
-      "integrity": "sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA=="
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.1.tgz",
+      "integrity": "sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw=="
     },
     "echarts": {
       "version": "5.3.3",
@@ -1366,11 +1164,6 @@
       "dev": true,
       "optional": true
     },
-    "estree-walker": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
-    },
     "fill-range": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
@@ -1471,14 +1264,6 @@
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
       "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
-    "magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "requires": {
-        "sourcemap-codec": "^1.4.8"
-      }
-    },
     "moment": {
       "version": "2.29.4",
       "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.4.tgz",
@@ -1578,11 +1363,6 @@
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
       "integrity": "sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw=="
     },
-    "sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
-    },
     "supports-preserve-symlinks-flag": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -1625,15 +1405,12 @@
       }
     },
     "vue": {
-      "version": "3.2.37",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.37.tgz",
-      "integrity": "sha512-bOKEZxrm8Eh+fveCqS1/NkG/n6aMidsI6hahas7pa0w/l7jkbssJVsRhVDs07IdDq7h9KHswZOgItnwJAgtVtQ==",
+      "version": "2.7.12",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-2.7.12.tgz",
+      "integrity": "sha512-yRS44vPsCj6b5IZQHdEYqIwnay8stCnL8RsaVsm5aGtOhka00aoG+3ybaBAELDsXtNlzECe8myb2ukdzn19IOg==",
       "requires": {
-        "@vue/compiler-dom": "3.2.37",
-        "@vue/compiler-sfc": "3.2.37",
-        "@vue/runtime-dom": "3.2.37",
-        "@vue/server-renderer": "3.2.37",
-        "@vue/shared": "3.2.37"
+        "@vue/compiler-sfc": "2.7.12",
+        "csstype": "^3.1.0"
       }
     },
     "zrender": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "preview": "vite preview"
   },
   "devDependencies": {
-    "@vitejs/plugin-vue": "^3.0.1",
+    "@vitejs/plugin-vue2": "^2.0.0",
     "sass": "^1.53.0",
     "vite": "^3.0.4"
   },
@@ -20,6 +20,6 @@
     "lodash": "^4.17.21",
     "moment": "^2.29.4",
     "tippy.js": "^6.3.7",
-    "vue": "^3.2.37"
+    "vue": "^2.7.12"
   }
 }

--- a/powa/static/js/main.js
+++ b/powa/static/js/main.js
@@ -1,5 +1,5 @@
 import _ from 'lodash';
-import { createApp } from 'vue';
+import Vue from 'vue';
 import store from './store';
 import Dashboard from './components/Dashboard.vue';
 import Graph from './components/Graph.vue';
@@ -14,7 +14,8 @@ import 'bootstrap';
 
 import 'bootstrap/dist/css/bootstrap.css'
 
-const app = createApp({
+const app = new Vue({
+  el: '#dashboard',
   components: {
     Dashboard
   },
@@ -26,13 +27,12 @@ const app = createApp({
 });
 
 
-app.component('dashboard', Dashboard);
-app.component('graph', Graph);
-app.component('grid', Grid);
-app.component('tabcontainer', Tabcontainer);
-app.component('wizard', Wizard);
-app.component('content-cmp', Content);
-const dashboard = app.mount("#dashboard");
+Vue.component('dashboard', Dashboard);
+Vue.component('graph', Graph);
+Vue.component('grid', Grid);
+Vue.component('tabcontainer', Tabcontainer);
+Vue.component('wizard', Wizard);
+Vue.component('content-cmp', Content);
 
 const colors = ["#c05020", "#30c020", "#6060c0"];
 // const ds = DataSourceCollection.get_instance();
@@ -57,7 +57,7 @@ $('script[type="text/datasources"]').each(function() {
 });
 
 $('script[type="text/dashboard"]').each(function(){
-  dashboard.$data.config = JSON.parse(this.text);
+  app.config = JSON.parse(this.text);
   //const widgetsEl = $('.widgets');
 
   //_.each(config.widgets, (w) => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,6 +1,6 @@
 import { resolve } from 'path'
 import { defineConfig } from 'vite'
-import vue from '@vitejs/plugin-vue'
+import vue from '@vitejs/plugin-vue2'
 
 // https://vitejs.dev/config/
 export default defineConfig({
@@ -9,7 +9,7 @@ export default defineConfig({
   ],
   resolve: {
     alias: {
-      'vue': 'vue/dist/vue.esm-bundler.js'
+      'vue': 'vue/dist/vue.esm.js'
     }
   },
   build: {


### PR DESCRIPTION
We aim to replace bootstrap-vue by vuetify.
Unfortunately vuetify 3 (compatible with vue3) is not ready yet.